### PR TITLE
Add tests for PDX scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Summary
+
+This repository contains a small web scraper for extracting vehicle details from the PDX Motors website.
+
+## Testing
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the test suite:
+
+```bash
+python3 -m unittest
+```

--- a/pdx_scraper.py
+++ b/pdx_scraper.py
@@ -1,0 +1,69 @@
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_car_details(url: str) -> dict:
+    """Fetches car details from a PDX Motors inventory page."""
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/114.0 Safari/537.36"
+    }
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, 'html.parser')
+
+    result = {}
+
+    # car title
+    title = soup.find('h1', class_='h4 title')
+    if title:
+        result['title'] = title.get_text(strip=True)
+
+    # price
+    price = soup.find('span', class_='dws-vdp-single-field-value-vehicleprice')
+    if price:
+        result['price'] = price.get_text(strip=True)
+
+    # mileage
+    mileage = soup.find('p', class_='dws-forms-mileage')
+    if mileage:
+        value_span = mileage.find('span', class_='dws-forms-value')
+        if value_span:
+            result['mileage'] = value_span.get_text(strip=True)
+
+    # VIN
+    vin = soup.find('p', class_='dws-forms-vin')
+    if vin:
+        value_span = vin.find('span', class_='dws-forms-value')
+        if value_span:
+            result['vin'] = value_span.get_text(strip=True)
+
+    # specs
+    specs = {}
+    spec_container = soup.find('dl', class_='vehicle-info')
+    if spec_container:
+        for item in spec_container.find_all('div', class_='info-item'):
+            term = item.find('dt')
+            description = item.find('dd')
+            if term and description:
+                specs[term.get_text(strip=True)] = description.get_text(strip=True)
+    if specs:
+        result['specs'] = specs
+
+    # description (fallback to og:description meta tag)
+    description = soup.find('meta', property='og:description')
+    if description and description.get('content'):
+        result['description'] = description['content']
+
+    return result
+
+
+def main():
+    url = 'https://www.pdxmotors.com/inventory/ferrari/f430/13912/'
+    details = fetch_car_details(url)
+    for k, v in details.items():
+        print(f"{k}: {v}")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/tests/sample_vehicle.html
+++ b/tests/sample_vehicle.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<meta property="og:description" content="This Ferrari is awesome">
+</head>
+<body>
+<h1 class="h4 title">2008 Ferrari F430</h1>
+<span class="dws-vdp-single-field-value-vehicleprice">$172,500</span>
+<p class="dws-forms-mileage">Mileage: <span class="dws-forms-value">23456</span></p>
+<p class="dws-forms-vin">VIN: <span class="dws-forms-value">ZFFEW58A580160000</span></p>
+<dl class="vehicle-info">
+  <div class="info-item">
+    <dt>Exterior</dt><dd>Red</dd>
+  </div>
+  <div class="info-item">
+    <dt>Interior</dt><dd>Tan</dd>
+  </div>
+</dl>
+</body>
+</html>

--- a/tests/test_pdx_scraper.py
+++ b/tests/test_pdx_scraper.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+from pathlib import Path
+
+import pdx_scraper
+
+
+def load_sample_html():
+    sample_path = Path(__file__).parent / 'sample_vehicle.html'
+    return sample_path.read_text()
+
+
+class MockResponse:
+    def __init__(self, text):
+        self.text = text
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+
+class PdxScraperTests(unittest.TestCase):
+    def test_fetch_car_details(self):
+        html = load_sample_html()
+        with patch('requests.get', return_value=MockResponse(html)):
+            data = pdx_scraper.fetch_car_details('https://example.com/test')
+
+        expected = {
+            'title': '2008 Ferrari F430',
+            'price': '$172,500',
+            'mileage': '23456',
+            'vin': 'ZFFEW58A580160000',
+            'specs': {
+                'Exterior': 'Red',
+                'Interior': 'Tan',
+            },
+            'description': 'This Ferrari is awesome',
+        }
+        self.assertEqual(data, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create sample HTML fixture for tests
- implement unit test for `fetch_car_details`
- document how to run tests

## Testing
- `python3 -m unittest -v tests/test_pdx_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_685048cd969c83308cee58321278d187