### PR TITLE
Add inventory parser for pdxmotors

### DIFF
--- a/tests/sample_inventory.html
+++ b/tests/sample_inventory.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<script type="text/javascript" src="/inv-scripts-v2/inv/vehicles?vc=a&f=id%7csn%7cma%7cmo&ps=2&pn=0&cb=mycb&dcid=111&h=abcd"></script>
+</body>
+</html>

--- a/tests/sample_inventory_page0.jsonp
+++ b/tests/sample_inventory_page0.jsonp
@@ -1,0 +1,1 @@
+mycb({"TotalRecordCount":3,"Vehicles":[{"Make":"Ford","Model":"F150","StockNumber":"111"},{"Make":"Tesla","Model":"Model X","StockNumber":"222"}]})

--- a/tests/sample_inventory_page1.jsonp
+++ b/tests/sample_inventory_page1.jsonp
@@ -1,0 +1,1 @@
+mycb({"TotalRecordCount":3,"Vehicles":[{"Make":"Mercedes-Benz","Model":"G-Class","StockNumber":"333"}]})


### PR DESCRIPTION
## Summary
- implement `fetch_inventory_links` to gather vehicle URLs
- create slug helper
- add inventory tests with sample responses

## Testing
- `python3 -m unittest`
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68504bbb6d00833097ac5b1038c759d6