### PR TITLE
Improve README and merge inventory features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This repository contains a small web scraper for extracting vehicle details from the PDX Motors website.
 
+## Inventory JSON
+
+Use `inventory_framework` to convert a list of inventory links to a JSON document.
+
+```python
+from inventory_framework import save_inventory_json
+
+urls = [
+    "https://www.pdxmotors.com/inventory/ferrari/f430/13912/",
+]
+save_inventory_json(urls, "inventory.json")
+```
+
 ## Testing
 
 Install dependencies:
@@ -13,5 +26,5 @@ pip install -r requirements.txt
 Run the test suite:
 
 ```bash
-python3 -m unittest
+python3 -m unittest discover -s tests -v
 ```

--- a/inventory_framework.py
+++ b/inventory_framework.py
@@ -1,0 +1,22 @@
+"""Utility for processing multiple inventory links and exporting data as JSON."""
+
+import json
+from typing import Iterable, List
+
+from pdx_scraper import fetch_car_details
+
+
+def inventory_to_json(links: Iterable[str]) -> str:
+    """Fetch details for all inventory links and return JSON string."""
+    data: List[dict] = []
+    for url in links:
+        details = fetch_car_details(url)
+        data.append(details)
+    return json.dumps(data, indent=2)
+
+
+def save_inventory_json(links: Iterable[str], filename: str) -> None:
+    """Fetch details for all links and save them to *filename* in JSON format."""
+    json_data = inventory_to_json(links)
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(json_data)

--- a/pdx_scraper.py
+++ b/pdx_scraper.py
@@ -1,15 +1,27 @@
+import argparse
 import requests
 from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse, parse_qs, urlencode, urlunparse
+import json
+import re
 
 
 def fetch_car_details(url: str) -> dict:
-    """Fetches car details from a PDX Motors inventory page."""
+    """Fetches car details from a PDX Motors inventory page.
+
+    Returns an empty dictionary if the request fails.
+    """
     headers = {
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/114.0 Safari/537.36"
     }
-    response = requests.get(url, headers=headers, timeout=10)
-    response.raise_for_status()
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Failed to fetch {url}: {exc}")
+        return {}
+
     soup = BeautifulSoup(response.text, 'html.parser')
 
     result = {}
@@ -58,9 +70,78 @@ def fetch_car_details(url: str) -> dict:
     return result
 
 
+def _slugify(value: str) -> str:
+    """Converts text into a slug suitable for URLs."""
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-+", "-", value)
+    return value.strip("-")
+
+
+def fetch_inventory_links(base_url: str = "https://www.pdxmotors.com/inventory/") -> list[str]:
+    """Returns a list of vehicle detail page URLs from the inventory."""
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/114.0 Safari/537.36",
+    }
+    response = requests.get(base_url, headers=headers, timeout=10)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    script = soup.find("script", src=re.compile(r"/inv-scripts-v2/inv/vehicles"))
+    if not script or not script.get("src"):
+        raise ValueError("Inventory script not found")
+
+    src_url = urljoin(base_url, script["src"])
+    parsed = urlparse(src_url)
+    query = parse_qs(parsed.query)
+
+    def fetch_page(page_num: int) -> dict:
+        q = query.copy()
+        q["pn"] = [str(page_num)]
+        page_url = urlunparse(parsed._replace(query=urlencode(q, doseq=True)))
+        r = requests.get(page_url, headers=headers, timeout=10)
+        r.raise_for_status()
+        m = re.search(r"\((\{.*\})\)", r.text)
+        if not m:
+            raise ValueError("Unexpected inventory response")
+        return json.loads(m.group(1))
+
+    first_page = fetch_page(0)
+    vehicles = list(first_page["Vehicles"])
+    total = first_page["TotalRecordCount"]
+    per_page = len(first_page["Vehicles"])
+    pages = (total + per_page - 1) // per_page
+
+    for pn in range(1, pages):
+        data = fetch_page(pn)
+        vehicles.extend(data.get("Vehicles", []))
+
+    links = []
+    for v in vehicles:
+        make_slug = _slugify(v["Make"])
+        model_slug = _slugify(v["Model"])
+        stock = v["StockNumber"]
+        links.append(
+            f"https://www.pdxmotors.com/inventory/{make_slug}/{model_slug}/{stock}/"
+        )
+
+    return links
+
+
 def main():
-    url = 'https://www.pdxmotors.com/inventory/ferrari/f430/13912/'
-    details = fetch_car_details(url)
+    parser = argparse.ArgumentParser(
+        description="Fetch car details from a PDX Motors inventory page"
+    )
+    parser.add_argument(
+        "url",
+        nargs="?",
+        default="https://www.pdxmotors.com/inventory/ferrari/f430/13912/",
+        help="Vehicle URL to scrape",
+    )
+    args = parser.parse_args()
+
+    details = fetch_car_details(args.url)
     for k, v in details.items():
         print(f"{k}: {v}")
 

--- a/tests/sample_inventory.html
+++ b/tests/sample_inventory.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<script type="text/javascript" src="/inv-scripts-v2/inv/vehicles?vc=a&f=id%7csn%7cma%7cmo&ps=2&pn=0&cb=mycb&dcid=111&h=abcd"></script>
+</body>
+</html>

--- a/tests/sample_inventory_page0.jsonp
+++ b/tests/sample_inventory_page0.jsonp
@@ -1,0 +1,1 @@
+mycb({"TotalRecordCount":3,"Vehicles":[{"Make":"Ford","Model":"F150","StockNumber":"111"},{"Make":"Tesla","Model":"Model X","StockNumber":"222"}]})

--- a/tests/sample_inventory_page1.jsonp
+++ b/tests/sample_inventory_page1.jsonp
@@ -1,0 +1,1 @@
+mycb({"TotalRecordCount":3,"Vehicles":[{"Make":"Mercedes-Benz","Model":"G-Class","StockNumber":"333"}]})

--- a/tests/test_inventory_framework.py
+++ b/tests/test_inventory_framework.py
@@ -1,0 +1,19 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import inventory_framework
+
+
+class InventoryFrameworkTests(unittest.TestCase):
+    def test_inventory_to_json(self):
+        links = ["http://example.com/1", "http://example.com/2"]
+        details = [{"title": "Car1"}, {"title": "Car2"}]
+        with patch("inventory_framework.fetch_car_details", side_effect=details):
+            data = inventory_framework.inventory_to_json(links)
+
+        self.assertEqual(json.loads(data), details)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- integrate inventory link parser from main
- add CLI argument for scraper
- handle network errors in `fetch_car_details`
- expand unit tests for scraper and inventory framework
- fix README test instructions

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68504d20fed083309b041affdcae6c61