### PR TITLE
Add Playwright option and docs

### DIFF
--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/playwright/python:v1.52.0-jammy
+
+WORKDIR /app
+
+COPY requirements.txt requirements.playwright.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -r requirements.playwright.txt \
+    && playwright install --with-deps
+
+COPY . .
+
+CMD ["python", "scrape_inventory_playwright.py"]

--- a/PLAYWRIGHT.md
+++ b/PLAYWRIGHT.md
@@ -1,0 +1,23 @@
+# Using Playwright
+
+This repository includes a Playwright-based scraper as an alternative to the
+original Requests/BeautifulSoup implementation. Below is a short overview of the
+benefits and potential drawbacks of using Playwright.
+
+## Benefits
+
+- **Handles dynamic pages**: Playwright can render JavaScript-driven pages,
+  enabling scraping of sites that rely heavily on client-side scripts.
+- **Cross-browser support**: Tests can run against Chromium, Firefox, or WebKit
+  with a single API.
+- **Powerful automation features**: Playwright offers robust capabilities for
+  navigation, element interaction and waiting for network events.
+
+## Drawbacks
+
+- **Heavier dependencies**: Playwright requires downloading browser binaries,
+  increasing setup time and disk usage.
+- **Slower startup**: Launching a browser instance introduces overhead compared
+  to plain HTTP requests.
+- **More complex testing**: Unit tests must manage browser contexts which can
+  slow down test execution.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Install dependencies:
 
 ```bash
 pip install -r requirements.txt
+pip install -r requirements.playwright.txt  # needed for Playwright
+playwright install
 ```
 
 Run the test suite:
@@ -41,4 +43,21 @@ Running the image will automatically download the full inventory from the PDX Mo
 
 ```bash
 docker run --rm pdx-scraper:latest
+```
+
+### Playwright option
+
+You can alternatively scrape using Playwright. Install the extra dependency and browsers, then run the dedicated script:
+
+```bash
+pip install -r requirements.playwright.txt
+playwright install
+python scrape_inventory_playwright.py
+```
+
+To containerize this approach, build and run the image defined in `Dockerfile.playwright`:
+
+```bash
+docker build -f Dockerfile.playwright -t pdx-scraper-playwright:latest .
+docker run --rm pdx-scraper-playwright:latest
 ```

--- a/pdx_scraper_playwright.py
+++ b/pdx_scraper_playwright.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urljoin, urlparse, parse_qs, urlencode, urlunparse
+
+from playwright.sync_api import sync_playwright
+
+
+def fetch_car_details(url: str, html: str | None = None) -> dict:
+    """Fetch car details using Playwright.
+
+    If *html* is provided, the browser will load that content instead of
+    navigating to *url*. This is useful for testing without network access.
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        if html is not None:
+            page.set_content(html)
+        else:
+            page.goto(url)
+
+        result: dict = {}
+
+        title = page.locator('h1.h4.title')
+        if title.count():
+            result['title'] = title.inner_text().strip()
+
+        price = page.locator('span.dws-vdp-single-field-value-vehicleprice')
+        if price.count():
+            result['price'] = price.inner_text().strip()
+
+        mileage = page.locator('p.dws-forms-mileage span.dws-forms-value')
+        if mileage.count():
+            result['mileage'] = mileage.inner_text().strip()
+
+        vin = page.locator('p.dws-forms-vin span.dws-forms-value')
+        if vin.count():
+            result['vin'] = vin.inner_text().strip()
+
+        specs = {}
+        for item in page.locator('dl.vehicle-info div.info-item').all():
+            term = item.locator('dt').inner_text().strip()
+            desc = item.locator('dd').inner_text().strip()
+            specs[term] = desc
+        if specs:
+            result['specs'] = specs
+
+        description = page.locator('meta[property="og:description"]')
+        if description.count():
+            content = description.get_attribute('content')
+            if content:
+                result['description'] = content
+
+        browser.close()
+    return result
+
+
+def _slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-+", "-", value)
+    return value.strip("-")
+
+
+def fetch_inventory_links(
+    base_url: str = "https://www.pdxmotors.com/inventory/",
+    base_html: str | None = None,
+    page_html: dict[int, str] | None = None,
+) -> list[str]:
+    """Return a list of vehicle detail page URLs using Playwright.
+
+    Parameters *base_html* and *page_html* allow injecting HTML content for
+    the inventory page and subsequent JSONP responses. This is primarily
+    intended for testing.
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        if base_html is not None:
+            page.set_content(base_html)
+        else:
+            page.goto(base_url)
+
+        script = page.locator('script[src*="/inv-scripts-v2/inv/vehicles"]')
+        if not script.count():
+            browser.close()
+            raise ValueError("Inventory script not found")
+        src_url = urljoin(base_url, script.get_attribute('src'))
+        parsed = urlparse(src_url)
+        query = parse_qs(parsed.query)
+
+        def fetch_page(pn: int) -> dict:
+            if page_html and pn in page_html:
+                page.set_content(page_html[pn])
+                text = page.inner_text('body')
+            else:
+                q = query.copy()
+                q['pn'] = [str(pn)]
+                page_url = urlunparse(parsed._replace(query=urlencode(q, doseq=True)))
+                page.goto(page_url)
+                text = page.inner_text('body')
+            m = re.search(r"\((\{.*\})\)", text)
+            if not m:
+                raise ValueError("Unexpected inventory response")
+            return json.loads(m.group(1))
+
+        first_page = fetch_page(0)
+        vehicles = list(first_page.get('Vehicles', []))
+        total = first_page.get('TotalRecordCount', len(vehicles))
+        per_page = len(first_page.get('Vehicles', [])) or 1
+        pages = (total + per_page - 1) // per_page
+
+        for pn in range(1, pages):
+            data = fetch_page(pn)
+            vehicles.extend(data.get('Vehicles', []))
+
+        browser.close()
+
+    links = []
+    for v in vehicles:
+        make_slug = _slugify(v['Make'])
+        model_slug = _slugify(v['Model'])
+        stock = v['StockNumber']
+        links.append(
+            f"https://www.pdxmotors.com/inventory/{make_slug}/{model_slug}/{stock}/"
+        )
+    return links

--- a/requirements.playwright.txt
+++ b/requirements.playwright.txt
@@ -1,0 +1,1 @@
+playwright

--- a/scrape_inventory_playwright.py
+++ b/scrape_inventory_playwright.py
@@ -1,0 +1,11 @@
+from inventory_framework import save_inventory_json
+from pdx_scraper_playwright import fetch_inventory_links
+
+
+def main() -> None:
+    links = fetch_inventory_links()
+    save_inventory_json(links, "inventory.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pdx_scraper_playwright.py
+++ b/tests/test_pdx_scraper_playwright.py
@@ -1,0 +1,59 @@
+import unittest
+from pathlib import Path
+
+from pdx_scraper_playwright import fetch_car_details, fetch_inventory_links
+
+
+def load_sample_html():
+    sample_path = Path(__file__).parent / 'sample_vehicle.html'
+    return sample_path.read_text()
+
+
+def load_inventory_html():
+    path = Path(__file__).parent / 'sample_inventory.html'
+    return path.read_text()
+
+
+def load_inventory_page0():
+    path = Path(__file__).parent / 'sample_inventory_page0.jsonp'
+    return path.read_text()
+
+
+def load_inventory_page1():
+    path = Path(__file__).parent / 'sample_inventory_page1.jsonp'
+    return path.read_text()
+
+
+class PlaywrightScraperTests(unittest.TestCase):
+    def test_fetch_car_details(self):
+        html = load_sample_html()
+        data = fetch_car_details('https://example.com/test', html=html)
+        expected = {
+            'title': '2008 Ferrari F430',
+            'price': '$172,500',
+            'mileage': '23456',
+            'vin': 'ZFFEW58A580160000',
+            'specs': {
+                'Exterior': 'Red',
+                'Interior': 'Tan',
+            },
+            'description': 'This Ferrari is awesome',
+        }
+        self.assertEqual(data, expected)
+
+    def test_fetch_inventory_links(self):
+        html = load_inventory_html()
+        page0 = load_inventory_page0()
+        page1 = load_inventory_page1()
+        pages = {0: page0, 1: page1}
+        links = fetch_inventory_links(base_html=html, page_html=pages)
+        expected_links = [
+            'https://www.pdxmotors.com/inventory/ford/f150/111/',
+            'https://www.pdxmotors.com/inventory/tesla/model-x/222/',
+            'https://www.pdxmotors.com/inventory/mercedes-benz/g-class/333/',
+        ]
+        self.assertEqual(links, expected_links)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create a standalone `requirements.playwright.txt`
- update Playwright Dockerfile to install additional requirements
- document how to run Playwright locally or via Docker

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements.playwright.txt`
- `playwright install` *(shows missing libs, but browsers download)*
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685055cb308c8330882c197c91e2f716